### PR TITLE
Cambiar los botones y el título de los terminales

### DIFF
--- a/view/tpv_recambios.html
+++ b/view/tpv_recambios.html
@@ -42,7 +42,7 @@
                <div class="page-header">
                   <h1>
                      <i class="fa fa-desktop" aria-hidden="true"></i>&nbsp;
-                     Terminal {$fsc->terminal->id}
+                      {$fsc->terminal->nombre}
                   </h1>
                   <p class="help-block">
                      El TPV imprime tickets y por tanto necesitas una impresora

--- a/view/tpv_recambios.html
+++ b/view/tpv_recambios.html
@@ -106,7 +106,7 @@
          {loop="$fsc->results"}
          <div class="col-sm-6">
             <a href="{$fsc->url()}&terminal={$value->id}" class="btn btn-block btn-default">
-               <i class="fa fa-desktop" aria-hidden="true"></i>&nbsp; Terminal {$value->id}
+               <i class="fa fa-desktop" aria-hidden="true"></i>&nbsp; {$fsc->terminal->nombre}
             </a>
          </div>
          {else}


### PR DESCRIPTION
Me parece que para los usuarios es más fácil identificar los terminales si nos referimos a ellos por el nombre (que además se puede personalizar en la configuración).

Es mi primer 'pull request' nunca he trabajado en público, espero poder ir ayudando en alguna cosa (si el tiempo lo permite :P)

¡Saludos!
