### PR TITLE
Corrige problema uso codigo de subcuentas reservadas para clientes

### DIFF
--- a/model/core/cliente.php
+++ b/model/core/cliente.php
@@ -439,8 +439,8 @@ class cliente extends \fs_model
          if($ccli)
          {
             $continuar = FALSE;
+            $subc0 = $this->new_subcuenta($ccli);
             
-            $subc0 = $ccli->new_subcuenta($this->codcliente);
             if($subc0)
             {
                $subc0->descripcion = $this->razonsocial;
@@ -487,7 +487,43 @@ class cliente extends \fs_model
       
       return $subcuenta;
    }
-   
+
+   /**
+   * Genera una subcuenta por defecto para clientes nacionales o extrangeros
+   * segun su divisa, usando cuenta cliente como argumento.
+   */
+   private function new_subcuenta($ccli){
+      $coddivisa_nacional = $this->default_items->coddivisa();
+      $scli = '';
+      $scli_nacional = array(
+              'EUR' => '00' , //4300
+              'COP' => '05' //130505
+            );
+      $scli_extrangero = array(
+              'EUR' => '01' , //4301
+              'COP' => '10' //130510
+            );
+
+      $conoce_subcuenta_nacional = array_key_exists($coddivisa_nacional,$scli_nacional);
+      $conoce_subcuenta_extrangero = array_key_exists($this->coddivisa,$scli_extrangero);
+
+      if ($conoce_subcuenta_nacional and $conoce_subcuenta_extrangero)
+      {
+        if ($coddivisa_nacional == $this->coddivisa )
+        {
+            $scli = $scli_nacional[$this->coddivisa];
+        }
+        else
+        {
+            $scli = $scli_extrangero[$this->coddivisa];
+        }
+
+        $ccli->codcuenta = $ccli->codcuenta.$scli;
+      }
+      
+      return  $ccli->new_subcuenta($this->codcliente);
+   }
+ 
    public function exists()
    {
       if( is_null($this->codcliente) )


### PR DESCRIPTION
- Ahora las subcuentas se generan automaticamente si el cliente es extrangero o nacional.
- Se protege el uso de cuentas reservadas para clientes segun la contabilida de cada pais (por el momento divisa EUR, COP)