### PR TITLE
Lista funcionalidad de convertir cliente en proveedor y viceversa

### DIFF
--- a/controller/compras_proveedor.php
+++ b/controller/compras_proveedor.php
@@ -270,7 +270,7 @@ class compras_proveedor extends fs_controller
       }
       else
       {
-         $this->new_error_msg("¡->proveedor no encontrado!", 'error', FALSE, FALSE);
+         $this->new_error_msg("¡Proveedor no encontrado!", 'error', FALSE, FALSE);
       }
    }
    

--- a/controller/compras_proveedor.php
+++ b/controller/compras_proveedor.php
@@ -23,6 +23,9 @@ require_model('forma_pago.php');
 require_model('pais.php');
 require_model('proveedor.php');
 require_model('serie.php');
+require_model('cliente.php');
+require_model('cuenta_banco_cliente.php');
+require_model('direccion_cliente.php');
 
 class compras_proveedor extends fs_controller
 {
@@ -179,10 +182,95 @@ class compras_proveedor extends fs_controller
             else
                $this->new_error_msg('¡Imposible modificar los datos del proveedor!');
          }
+         else if( isset($_GET['convertir']) ) /// convertir a cliente
+         {
+	         	$cliente = new cliente();
+	         	
+	         	/* datos generales */
+	         	$cliente->nombre = $this->proveedor->nombre;
+	         	$cliente->razonsocial = $this->proveedor->razonsocial;
+	         	$cliente->tipoidfiscal = $this->proveedor->tipoidfiscal;
+	         	$cliente->cifnif = $this->proveedor->cifnif;
+	         	$cliente->telefono1 = $this->proveedor->telefono1;
+	         	$cliente->telefono2 = $this->proveedor->telefono2;
+	         	$cliente->fax = $this->proveedor->fax;
+	         	$cliente->web = $this->proveedor->web;
+	         	$cliente->email = $this->proveedor->email;
+	         	$cliente->observaciones = $this->proveedor->observaciones;
+	         	$cliente->codpago = $this->proveedor->codpago;
+	         	$cliente->coddivisa = $this->proveedor->coddivisa;
+	         	$cliente->regimeniva = $this->proveedor->regimeniva;
+	         	$cliente->recargo = $this->proveedor->recargo;
+	         	$cliente->debaja = $this->proveedor->debaja;
+	         	$cliente->fechabaja = $this->proveedor->fechabaja;
+	         	$cliente->personafisica = $this->proveedor->personafisica;
+	         	$cliente->diaspago = $this->proveedor->diaspago;
+	         	$cliente->codserie = $this->proveedor->codserie;
+	         	$cliente->codagente = $this->proveedor->codagente;
+	         	$cliente->codgrupo = $this->proveedor->codgrupo;
+	         	$cliente->codproveedor = $this->proveedor->codproveedor;
+	
+	         	/* salvamos el cliente */
+	         	$cliente_ok = true;
+	         	if( $cliente->save() )
+	         	{
+	         		$this->proveedor->codcliente = $cliente->codcliente;
+	         		$cliente_ok = $cliente_ok && $this->proveedor->save();
+	         	}
+	         	else
+	         		$cliente_ok = false;
+	         			
+	         		/* sólo si fue bien el salvado */
+	         	if ($cliente_ok)
+	         	{
+	         		/* cuentas de banco */
+	         		$cuentas_banco_pro = $this->cuenta_banco->all_from_proveedor($this->proveedor->codproveedor);
+	         		$cbancos_ok = true;
+	         		foreach ($cuentas_banco_pro as $c)
+	         		{
+         					$c_banco_cliente = new cuenta_banco_cliente();
+         					$c_banco_cliente->codcuenta = $c->codcuenta;
+         					$c_banco_cliente->codcliente = $cliente->codcliente;
+         					$c_banco_cliente->descripcion = $c->descripcion;
+         					$c_banco_cliente->iban = $c->iban;
+         					$c_banco_cliente->swift = $c->swift;
+         					$c_banco_cliente->principal = $c->principal;
+         					$cbancos_ok = $cbancos_ok && $c_banco_cliente->save();
+	         		}
+	         					
+	         		/* direcciones */
+	         		$direcc_pro = $this->proveedor->get_direcciones();
+	         		$direcc_ok = true;
+	         		foreach ($direcc_pro as $d)
+	         		{
+         					$direcc_cli = new direccion_cliente();
+         					$direcc_cli->codcliente = $cliente->codcliente;
+         					$direcc_cli->codpais = $d->codpais;
+         					$direcc_cli->apartado = $d->apartado;
+         					$direcc_cli->provincia = $d->provincia;
+         					$direcc_cli->ciudad = $d->ciudad;
+         					$direcc_cli->codpostal = $d->codpostal;
+         					$direcc_cli->direccion = $d->direccion;
+         					$direcc_cli->direccionppal = $d->direccionppal;
+         					$direcc_cli->descripcion = $d->descripcion;
+         					$direcc_cli = $direcc_ok && $direcc_cli->save();
+	         		}
+	         	}
+	         				
+	         	/* resultado */
+	         	if( $cliente_ok )
+	         	{
+	         		$txtadded = $cbancos_ok ? "" : ". No se pudieron copiar todas las cuentas bancarias";
+	         		$txtadded .= $direcc_ok ? "" : ". No se pudieron copiar todas las direcciones";
+	         		$this->new_message("Conversión correcta. Cliente ".$cliente->codcliente.$txtadded);
+	         	}
+	         	else
+	         		$this->new_error_msg("¡Imposible realizar la conversión!");
+		 }
       }
       else
       {
-         $this->new_error_msg("¡Proveedor no encontrado!", 'error', FALSE, FALSE);
+         $this->new_error_msg("¡->proveedor no encontrado!", 'error', FALSE, FALSE);
       }
    }
    

--- a/controller/ventas_cliente.php
+++ b/controller/ventas_cliente.php
@@ -1,7 +1,4 @@
 <?php
-use FacturaScripts\model\proveedor;
-use FacturaScripts\model\direccion_proveedor;
-
 /*
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  neorazorx@gmail.com

--- a/controller/ventas_cliente.php
+++ b/controller/ventas_cliente.php
@@ -212,7 +212,7 @@ class ventas_cliente extends fs_controller
             else
                $this->new_error_msg("¡Imposible modificar los datos del cliente!");
          }
-         else if( isset($_GET['convertir']) ) /// eliminar dirección
+         else if( isset($_GET['convertir']) ) 
          {
          	$proveedor = new proveedor();
          	

--- a/controller/ventas_cliente.php
+++ b/controller/ventas_cliente.php
@@ -1,4 +1,7 @@
 <?php
+use FacturaScripts\model\proveedor;
+use FacturaScripts\model\direccion_proveedor;
+
 /*
  * This file is part of FacturaScripts
  * Copyright (C) 2013-2017  Carlos Garcia Gomez  neorazorx@gmail.com
@@ -26,6 +29,9 @@ require_model('forma_pago.php');
 require_model('grupo_clientes.php');
 require_model('pais.php');
 require_model('serie.php');
+require_model('proveedor.php');
+require_model('cuenta_banco_proveedor.php');
+require_model('direccion_proveedor.php');
 
 class ventas_cliente extends fs_controller
 {
@@ -130,7 +136,7 @@ class ventas_cliente extends fs_controller
             else
                $this->new_message("¡Imposible guardar la dirección!");
          }
-         else if( isset($_POST['iban']) ) /// añadir/modificar dirección
+         else if( isset($_POST['iban']) ) /// añadir/modificar iban
          {
             if( isset($_POST['codcuenta']) )
             {
@@ -208,6 +214,91 @@ class ventas_cliente extends fs_controller
             }
             else
                $this->new_error_msg("¡Imposible modificar los datos del cliente!");
+         }
+         else if( isset($_GET['convertir']) ) /// eliminar dirección
+         {
+         	$proveedor = new proveedor();
+         	
+         	/* datos generales */
+         	$proveedor->nombre = $this->cliente->nombre;
+         	$proveedor->razonsocial = $this->cliente->razonsocial;
+         	$proveedor->tipoidfiscal = $this->cliente->tipoidfiscal;
+         	$proveedor->cifnif = $this->cliente->cifnif;
+         	$proveedor->telefono1 = $this->cliente->telefono1;
+         	$proveedor->telefono2 = $this->cliente->telefono2;
+         	$proveedor->fax = $this->cliente->fax;
+         	$proveedor->web = $this->cliente->web;
+         	$proveedor->email = $this->cliente->email;
+         	$proveedor->observaciones = $this->cliente->observaciones;
+         	$proveedor->codpago = $this->cliente->codpago;
+         	$proveedor->coddivisa = $this->cliente->coddivisa;
+         	$proveedor->regimeniva = $this->cliente->regimeniva;
+         	$proveedor->recargo = $this->cliente->recargo;
+         	$proveedor->debaja = $this->cliente->debaja;
+         	$proveedor->fechabaja = $this->cliente->fechabaja;
+         	$proveedor->personafisica = $this->cliente->personafisica;
+         	$proveedor->diaspago = $this->cliente->diaspago;
+         	$proveedor->codserie = $this->cliente->codserie;
+         	$proveedor->codagente = $this->cliente->codagente;         	
+         	$proveedor->codgrupo = $this->cliente->codgrupo;         	
+         	$proveedor->codcliente = $this->cliente->codcliente;
+         	
+         	/* salvamos el proveedor */
+         	$proveedor_ok = true;
+         	if( $proveedor->save() )
+         	{
+         		$this->cliente->codproveedor = $proveedor->codproveedor;
+         		$proveedor_ok = $proveedor_ok && $this->cliente->save();
+         	}
+         	else
+         		$proveedor_ok = false;
+         	
+         	/* sólo si fue bien el salvado */
+         	if ($proveedor_ok)
+         	{
+	         	/* cuentas de banco */
+	         	$cuentas_banco_cli = $this->cuenta_banco->all_from_cliente($this->cliente->codcliente);
+	         	$cbancos_ok = true;
+	         	foreach ($cuentas_banco_cli as $c)
+	         	{
+	         		$c_banco_proveedor = new cuenta_banco_proveedor();
+	         		$c_banco_proveedor->codcuenta = $c->codcuenta;
+	         		$c_banco_proveedor->codproveedor = $proveedor->codproveedor;
+	         		$c_banco_proveedor->descripcion = $c->descripcion;
+	         		$c_banco_proveedor->iban = $c->iban;
+	         		$c_banco_proveedor->swift = $c->swift;
+	  				$c_banco_proveedor->principal = $c->principal;
+	   				$cbancos_ok = $cbancos_ok && $c_banco_proveedor->save(); 
+	         	}
+	         	
+	         	/* direcciones */
+	         	$direcc_cli = $this->cliente->get_direcciones();
+	         	$direcc_ok = true;
+	         	foreach ($direcc_cli as $d)
+	         	{
+	         		$direcc_pro = new direccion_proveedor();
+	         		$direcc_pro->codproveedor = $proveedor->codproveedor;
+	         		$direcc_pro->codpais = $d->codpais;
+	         		$direcc_pro->apartado = $d->apartado;
+	         		$direcc_pro->provincia = $d->provincia;
+	         		$direcc_pro->ciudad = $d->ciudad;
+	         		$direcc_pro->codpostal = $d->codpostal;
+	         		$direcc_pro->direccion = $d->direccion;
+	         		$direcc_pro->direccionppal = $d->direccionppal;
+	         		$direcc_pro->descripcion = $d->descripcion;         		
+	         		$direcc_ok = $direcc_ok && $direcc_pro->save();
+	         	}
+         	}
+         	
+         	/* resultado */
+         	if( $proveedor_ok )
+         	{
+         		$txtadded = $cbancos_ok ? "" : ". No se pudieron copiar todas las cuentas bancarias";
+         		$txtadded .= $direcc_ok ? "" : ". No se pudieron copiar todas las direcciones";
+         		$this->new_message("Conversión correcta. Proveedor ".$proveedor->codproveedor.$txtadded);
+         	}
+         	else
+         		$this->new_error_msg("¡Imposible realizar la conversión!");
          }
       }
       else

--- a/model/core/cliente.php
+++ b/model/core/cliente.php
@@ -146,6 +146,12 @@ class cliente extends \fs_model
     */
    public $diaspago;
    
+   /**
+    * Proveedor asociado equivalente
+    * @var type
+    */
+   public $codproveedor;
+   
    private static $regimenes_iva;
 
    public function __construct($c = FALSE)
@@ -191,6 +197,7 @@ class cliente extends \fs_model
          $this->recargo = $this->str2bool($c['recargo']);
          $this->personafisica = $this->str2bool($c['personafisica']);
          $this->diaspago = $c['diaspago'];
+         $this->codproveedor = $c['codproveedor'];
       }
       else
       {
@@ -224,6 +231,7 @@ class cliente extends \fs_model
          $this->recargo = FALSE;
          $this->personafisica = TRUE;
          $this->diaspago = NULL;
+         $this->codproveedor = NULL;
       }
    }
    
@@ -530,6 +538,7 @@ class cliente extends \fs_model
       $this->razonsocial = $this->no_html($this->razonsocial);
       $this->cifnif = $this->no_html($this->cifnif);
       $this->observaciones = $this->no_html($this->observaciones);
+      $this->codproveedor = trim($this->codproveedor);
       
       if($this->debaja)
       {
@@ -606,13 +615,14 @@ class cliente extends \fs_model
                     .", recargo = ".$this->var2str($this->recargo)
                     .", personafisica = ".$this->var2str($this->personafisica)
                     .", diaspago = ".$this->var2str($this->diaspago)
+                    .", codproveedor = ".$this->var2str($this->codproveedor)
                     ."  WHERE codcliente = ".$this->var2str($this->codcliente).";";
          }
          else
          {
             $sql = "INSERT INTO ".$this->table_name." (codcliente,nombre,razonsocial,tipoidfiscal,
                cifnif,telefono1,telefono2,fax,email,web,codserie,coddivisa,codpago,codagente,codgrupo,
-               debaja,fechabaja,fechaalta,observaciones,regimeniva,recargo,personafisica,diaspago) VALUES
+               debaja,fechabaja,fechaalta,observaciones,regimeniva,recargo,personafisica,diaspago,codproveedor) VALUES
                       (".$this->var2str($this->codcliente)
                     .",".$this->var2str($this->nombre)
                     .",".$this->var2str($this->razonsocial)
@@ -635,7 +645,8 @@ class cliente extends \fs_model
                     .",".$this->var2str($this->regimeniva)
                     .",".$this->var2str($this->recargo)
                     .",".$this->var2str($this->personafisica)
-                    .",".$this->var2str($this->diaspago).");";
+                    .",".$this->var2str($this->diaspago)
+                    .",".$this->var2str($this->codproveedor).");";
          }
          
          return $this->db->exec($sql);

--- a/model/core/proveedor.php
+++ b/model/core/proveedor.php
@@ -121,6 +121,12 @@ class proveedor extends \fs_model
     */
    public $fechabaja;
    
+   /**
+    * Cliente asociado equivalente
+    * @var type
+    */
+   public $codcliente;
+   
    private static $regimenes_iva;
    
    public function __construct($p=FALSE)
@@ -157,6 +163,7 @@ class proveedor extends \fs_model
 
          $this->debaja = $this->str2bool($p['debaja']);
          $this->fechabaja = date('d-m-Y');
+         $this->codcliente = $p['codcliente'];
       }
       else
       {
@@ -188,6 +195,7 @@ class proveedor extends \fs_model
 
          $this->debaja = FALSE;
          $this->fechabaja = NULL;
+         $this->codcliente = NULL;
       }
    }
    
@@ -504,6 +512,7 @@ class proveedor extends \fs_model
       $this->razonsocial = $this->no_html($this->razonsocial);
       $this->cifnif = $this->no_html($this->cifnif);
       $this->observaciones = $this->no_html($this->observaciones);
+      $this->codcliente = trim($this->codcliente);
       
       if( !preg_match("/^[A-Z0-9]{1,6}$/i", $this->codproveedor) )
       {
@@ -549,13 +558,14 @@ class proveedor extends \fs_model
                     ", personafisica = ".$this->var2str($this->personafisica).
                     ", debaja = ".$this->var2str($this->debaja).
                     ", fechabaja = ".$this->var2str($this->fechabaja).
+                    ", codcliente = ".$this->var2str($this->codcliente).
                     " WHERE codproveedor = ".$this->var2str($this->codproveedor).";";
          }
          else
          {
             $sql = "INSERT INTO ".$this->table_name." (codproveedor,nombre,razonsocial,tipoidfiscal,cifnif,
                telefono1,telefono2,fax,email,web,codserie,coddivisa,codpago,observaciones,
-               regimeniva,acreedor,personafisica,debaja,fechabaja) VALUES (".$this->var2str($this->codproveedor).
+               regimeniva,acreedor,personafisica,debaja,fechabaja,codcliente) VALUES (".$this->var2str($this->codproveedor).
                     ",".$this->var2str($this->nombre).
                     ",".$this->var2str($this->razonsocial).
                     ",".$this->var2str($this->tipoidfiscal).
@@ -573,7 +583,8 @@ class proveedor extends \fs_model
                     ",".$this->var2str($this->acreedor).
                     ",".$this->var2str($this->personafisica).
                     ",".$this->var2str($this->debaja).
-                    ",".$this->var2str($this->fechabaja).");";
+                    ",".$this->var2str($this->fechabaja).
+                    ",".$this->var2str($this->codcliente).");";
          }
          
          return $this->db->exec($sql);

--- a/model/table/clientes.xml
+++ b/model/table/clientes.xml
@@ -186,6 +186,11 @@
       <nombre>diaspago</nombre>
       <tipo>character varying(10)</tipo>
    </columna>
+   <columna>
+      <nombre>codproveedor</nombre>
+      <tipo>character varying(6)</tipo>
+      <nulo>YES</nulo>
+   </columna>
    <restriccion>
       <nombre>clientes_pkey</nombre>
       <consulta>PRIMARY KEY (codcliente)</consulta>

--- a/model/table/proveedores.xml
+++ b/model/table/proveedores.xml
@@ -142,6 +142,11 @@
       <tipo>date</tipo>
       <nulo>YES</nulo>
    </columna>
+   <columna>
+      <nombre>codcliente</nombre>
+      <tipo>character varying(6)</tipo>
+      <nulo>YES</nulo>
+   </columna>
    <restriccion>
       <nombre>proveedores_pkey</nombre>
       <consulta>PRIMARY KEY (codproveedor)</consulta>

--- a/view/compras_proveedor.html
+++ b/view/compras_proveedor.html
@@ -342,6 +342,10 @@
                         </div>
                      </div>
                      <div class="panel-footer text-right">
+                        <a href="#" class="btn btn-sm btn-primary" data-toggle="modal" data-target="#modal_convertir">
+ 			               <span class="glyphicon glyphicon-random"></span>
+ 			               <span class="hidden-xs">&nbsp;Convertir en cliente</span>
+ 			            </a>
                         <button class="btn btn-sm btn-primary" type="submit" onclick="this.disabled=true;this.form.submit();">
                            <span class="glyphicon glyphicon-floppy-disk"></span>&nbsp; Guardar
                         </button>
@@ -395,7 +399,41 @@
                               </div>
                            </div>
                         </div>
-                    </div>                  
+                    </div>
+                    <div class="modal fade" id="modal_convertir" tabindex="-1" role="dialog">
+                     <div class="modal-dialog" role="document">
+                       <div class="modal-content">
+                           <div class="modal-header">
+                              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                 <span aria-hidden="true">&times;</span>
+                              </button>                              
+                              <h4 class="modal-title">
+                                 <span class="glyphicon glyphicon-lock"></span>
+                                 &nbsp; ¿Convertir en cliente?
+                              </h4>
+                              <p class="help-block">
+                                 Se insertará un nuevo cliente en el sistema con los mismos datos
+                              </p>
+                           </div>
+                           <div class="modal-body">
+                              <div class="form-group">                                 
+                                 <p class="help-block">
+                                    El nuevo cliente y el proveedor actual quedarán asociados internamente.
+                                 </p>
+                                 <p class="help-block">
+                                    No se clonarán los datos que no se hayan guardado previamente con el botón "Guardar".
+                                 </p>
+                              </div>
+                              <input type="hidden" name="convertir" value="TRUE"/>
+                              <div class="text-right">
+                                 <button class="btn btn-sm btn-primary" type="submit" onclick="this.disabled=true;window.location.href = '{$fsc->url()}&cod={$fsc->proveedor->codproveedor}&convertir=1';">
+                                    <span class="glyphicon glyphicon-random"></span>&nbsp; Convertir
+                                 </button>
+                              </div>
+                           </div>
+                        </div>
+                     </div>
+                  </div>                  
                   
                </form>
             </div>

--- a/view/ventas_cliente.html
+++ b/view/ventas_cliente.html
@@ -372,9 +372,13 @@
                         </div>
                      </div>
                      <div class="panel-footer text-right">
-                        <small class="pull-left">Fecha de alta: {$fsc->cliente->fechaalta}</small>
+                        <small class="pull-left">Fecha de alta: {$fsc->cliente->fechaalta}</small>                        
+                        <a href="#" class="btn btn-sm btn-primary" data-toggle="modal" data-target="#modal_convertir">
+			               <span class="glyphicon glyphicon-random"></span>
+			               <span class="hidden-xs">&nbsp;Convertir en proveedor</span>
+			            </a>
                         <button class="btn btn-sm btn-primary" type="submit" onclick="this.disabled=true;this.form.submit();">
-                           <span class="glyphicon glyphicon-floppy-disk"></span>&nbsp; Guardar
+                           <span class="glyphicon glyphicon glyphicon-disk"></span>&nbsp; Guardar
                         </button>
                      </div>
                   </div>
@@ -421,6 +425,40 @@
                               <div class="text-right">
                                  <button class="btn btn-sm btn-primary" type="submit" onclick="this.disabled=true;this.form.submit();">
                                     <span class="glyphicon glyphicon-floppy-disk"></span>&nbsp; Guardar
+                                 </button>
+                              </div>
+                           </div>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="modal fade" id="modal_convertir" tabindex="-1" role="dialog">
+                     <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                           <div class="modal-header">
+                              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                 <span aria-hidden="true">&times;</span>
+                              </button>                              
+                              <h4 class="modal-title">
+                                 <span class="glyphicon glyphicon-lock"></span>
+                                 &nbsp; ¿Convertir en proveedor?
+                              </h4>
+                              <p class="help-block">
+                                 Se insertará un nuevo proveedor en el sistema con los mismos datos
+                              </p>
+                           </div>
+                           <div class="modal-body">
+                              <div class="form-group">                                 
+                                 <p class="help-block">
+                                    El nuevo proveedor y el cliente actual quedarán asociados internamente.
+                                 </p>
+                                 <p class="help-block">
+                                    No se clonarán los datos que no se hayan guardado previamente con el botón "Guardar".
+                                 </p>
+                              </div>
+                              <input type="hidden" name="convertir" value="TRUE"/>
+                              <div class="text-right">
+                                 <button class="btn btn-sm btn-primary" type="submit" onclick="this.disabled=true;window.location.href = '{$fsc->url()}&cod={$fsc->cliente->codcliente}&convertir=1';">
+                                    <span class="glyphicon glyphicon-random"></span>&nbsp; Convertir
                                  </button>
                               </div>
                            </div>

--- a/view/ventas_cliente.html
+++ b/view/ventas_cliente.html
@@ -378,7 +378,7 @@
 			               <span class="hidden-xs">&nbsp;Convertir en proveedor</span>
 			            </a>
                         <button class="btn btn-sm btn-primary" type="submit" onclick="this.disabled=true;this.form.submit();">
-                           <span class="glyphicon glyphicon glyphicon-disk"></span>&nbsp; Guardar
+                           <span class="glyphicon glyphicon-floppy-disk"></span>&nbsp; Guardar
                         </button>
                      </div>
                   </div>


### PR DESCRIPTION
En la pestaña Datos Generales tanto de cliente como proveedor hay un nuevo botón junto a "Guardar". Si se pulsa se abre un modal donde se explica lo que significa "convertir a proveedor" o "convertir a cliente".

Al "clonar" de uno a otro se copian también las cuentas bancarias y las direcciones. 

Se ha creado además un índice interno en cada tabla (codproveedor y codcliente) que apuntan uno a otro para mantener las referencias, esto es, si con el cliente 0001 lo convierto a proveedor y se crea el proveedor 0007, se rellena el campo en db "codproveedor = 0007" en el cliente 0001 y se rellena el campo en db "codcliente = 0001" en el proveedor 0007. 

