### PR TITLE
Comprueba que descripcion esté vacio

### DIFF
--- a/model/core/proveedor.php
+++ b/model/core/proveedor.php
@@ -388,7 +388,9 @@ class proveedor extends \fs_model
 
                 $subc0 = $cpro->new_subcuenta($this->codproveedor);
                 if ($subc0) {
-                    $subc0->descripcion = $this->razonsocial;
+                    if(empty($subc0->descripcion)) {
+                        $subc0->descripcion = $this->razonsocial;
+                    }
                     if ($subc0->save()) {
                         $continuar = TRUE;
                     }


### PR DESCRIPTION
Evitamos sobreescribir la descripcion de la subcuenta en los casos en que new_subcuenta devuelve una subcuenta preexistente.