### PR TITLE
Leve modificación en observaciones al aprobar

### DIFF
--- a/extras/fbase_controller.php
+++ b/extras/fbase_controller.php
@@ -501,7 +501,9 @@ class fbase_controller extends fs_controller
         $factura->codpago = $albaranes[0]->codpago;
         $factura->codserie = $albaranes[0]->codserie;
         $factura->irpf = $albaranes[0]->irpf;
-        $factura->observaciones = $albaranes[0]->observaciones;
+        if (count($albaranes) == 1) {
+            $factura->observaciones = $albaranes[0]->observaciones;
+        }
 
         /// obtenemos los datos actualizados del proveedor
         $proveedor_model = new proveedor();

--- a/extras/fbase_controller.php
+++ b/extras/fbase_controller.php
@@ -306,7 +306,9 @@ class fbase_controller extends fs_controller
 
         $factura->codserie = $albaranes[0]->codserie;
         $factura->irpf = $albaranes[0]->irpf;
-        $factura->observaciones = $albaranes[0]->observaciones;
+        if (count($albaranes) == 1) {
+            $factura->observaciones = $albaranes[0]->observaciones;
+        }
         $factura->apartado = $albaranes[0]->apartado;
         $factura->cifnif = $albaranes[0]->cifnif;
         $factura->ciudad = $albaranes[0]->ciudad;


### PR DESCRIPTION
Si se están agrupando múltiples albaranes en 1 factura, no es necesario copiar las observaciones, porqué al ser una recapitulación de documentos pueden haber diversos comentarios diferentes y ninguno tiene que ser el adecuado para dicha agrupación.