### PR TITLE
[FIX] Evita cambio no deseado de referencia

### DIFF
--- a/controller/ventas_articulo.php
+++ b/controller/ventas_articulo.php
@@ -389,7 +389,8 @@ class ventas_articulo extends fbase_controller
             /**
              * Renombramos la referencia en el resto de tablas: lineasalbaranes, lineasfacturas...
              */
-            if ($_POST['nreferencia'] != $_POST['referencia']) {
+            $new_art = (new articulo())->get($_POST['nreferencia']);
+            if ($_POST['nreferencia'] != $_POST['referencia'] && !$new_art) {
                 if ($this->db->table_exists('lineasalbaranescli')) {
                     $this->db->exec("UPDATE lineasalbaranescli SET referencia = " . $this->empresa->var2str($_POST['nreferencia'])
                         . " WHERE referencia = " . $this->empresa->var2str($_POST['referencia']) . ";");
@@ -442,6 +443,8 @@ class ventas_articulo extends fbase_controller
                         . " WHERE referencia = " . $this->empresa->var2str($_POST['referencia']) . ";");
                     $this->new_message("Reemplazo masivo en lineasfabricados reemplazada referencia " . $this->empresa->var2str($_POST['referencia']) . " por " . $this->empresa->var2str($_POST['nreferencia']), true);
                 }
+            } elseif ($_POST['nreferencia'] != $_POST['referencia'] && $new_art) {
+                $this->new_error_msg('No se puede cambiar la referencia de ' . $_POST['referencia'] . ' a ' . $_POST['nreferencia'] . ' porqué ya existe.');
             }
         } else {
             $this->new_error_msg("¡Error al guardar el articulo!");

--- a/controller/ventas_articulo.php
+++ b/controller/ventas_articulo.php
@@ -389,30 +389,59 @@ class ventas_articulo extends fbase_controller
             /**
              * Renombramos la referencia en el resto de tablas: lineasalbaranes, lineasfacturas...
              */
-            if ($this->db->table_exists('lineasalbaranescli')) {
-                $this->db->exec("UPDATE lineasalbaranescli SET referencia = " . $this->empresa->var2str($_POST['nreferencia'])
-                    . " WHERE referencia = " . $this->empresa->var2str($_POST['referencia']) . ";");
-            }
+            if ($_POST['nreferencia'] != $_POST['referencia']) {
+                if ($this->db->table_exists('lineasalbaranescli')) {
+                    $this->db->exec("UPDATE lineasalbaranescli SET referencia = " . $this->empresa->var2str($_POST['nreferencia'])
+                        . " WHERE referencia = " . $this->empresa->var2str($_POST['referencia']) . ";");
+                    $this->new_message("Reemplazo masivo en lineasalbaranescli reemplazada referencia " . $this->empresa->var2str($_POST['referencia']) . " por " . $this->empresa->var2str($_POST['nreferencia']), true);
+                }
 
-            if ($this->db->table_exists('lineasalbaranesprov')) {
-                $this->db->exec("UPDATE lineasalbaranesprov SET referencia = " . $this->empresa->var2str($_POST['nreferencia'])
-                    . " WHERE referencia = " . $this->empresa->var2str($_POST['referencia']) . ";");
-            }
+                if ($this->db->table_exists('lineasalbaranesprov')) {
+                    $this->db->exec("UPDATE lineasalbaranesprov SET referencia = " . $this->empresa->var2str($_POST['nreferencia'])
+                        . " WHERE referencia = " . $this->empresa->var2str($_POST['referencia']) . ";");
+                    $this->new_message("Reemplazo masivo en lineasalbaranesprov reemplazada referencia " . $this->empresa->var2str($_POST['referencia']) . " por " . $this->empresa->var2str($_POST['nreferencia']), true);
+                }
 
-            if ($this->db->table_exists('lineasfacturascli')) {
-                $this->db->exec("UPDATE lineasfacturascli SET referencia = " . $this->empresa->var2str($_POST['nreferencia'])
-                    . " WHERE referencia = " . $this->empresa->var2str($_POST['referencia']) . ";");
-            }
+                if ($this->db->table_exists('lineasfacturascli')) {
+                    $this->db->exec("UPDATE lineasfacturascli SET referencia = " . $this->empresa->var2str($_POST['nreferencia'])
+                        . " WHERE referencia = " . $this->empresa->var2str($_POST['referencia']) . ";");
+                    $this->new_message("Reemplazo masivo en lineasfacturascli reemplazada referencia " . $this->empresa->var2str($_POST['referencia']) . " por " . $this->empresa->var2str($_POST['nreferencia']), true);
+                }
 
-            if ($this->db->table_exists('lineasfacturasprov')) {
-                $this->db->exec("UPDATE lineasfacturasprov SET referencia = " . $this->empresa->var2str($_POST['nreferencia'])
-                    . " WHERE referencia = " . $this->empresa->var2str($_POST['referencia']) . ";");
-            }
+                if ($this->db->table_exists('lineasfacturasprov')) {
+                    $this->db->exec("UPDATE lineasfacturasprov SET referencia = " . $this->empresa->var2str($_POST['nreferencia'])
+                        . " WHERE referencia = " . $this->empresa->var2str($_POST['referencia']) . ";");
+                    $this->new_message("Reemplazo masivo en lineasfacturasprov reemplazada referencia " . $this->empresa->var2str($_POST['referencia']) . " por " . $this->empresa->var2str($_POST['nreferencia']), true);
+                }
 
-            /// esto es una personalización del plugin producción, será eliminado este código en futuras versiones.
-            if ($this->db->table_exists('lineasfabricados')) {
-                $this->db->exec("UPDATE lineasfabricados SET referencia = " . $this->empresa->var2str($_POST['nreferencia'])
-                    . " WHERE referencia = " . $this->empresa->var2str($_POST['referencia']) . ";");
+                /**
+                 * Renombramos la referencia en el resto de tablas: lineaspedidoscli, lineaspedidosprov, lineaspresupuestoscli
+                 * si está presupuestos_y_pedidos cargado.
+                 */
+                if ($this->db->table_exists('lineaspresupuestoscli')) {
+                    $this->db->exec("UPDATE lineaspresupuestoscli SET referencia = " . $this->empresa->var2str($_POST['nreferencia'])
+                        . " WHERE referencia = " . $this->empresa->var2str($_POST['referencia']) . ";");
+                    $this->new_message("Reemplazo masivo en lineaspresupuestoscli reemplazada referencia " . $this->empresa->var2str($_POST['referencia']) . " por " . $this->empresa->var2str($_POST['nreferencia']), true);
+                }
+
+                if ($this->db->table_exists('lineaspedidoscli')) {
+                    $this->db->exec("UPDATE lineaspedidoscli SET referencia = " . $this->empresa->var2str($_POST['nreferencia'])
+                        . " WHERE referencia = " . $this->empresa->var2str($_POST['referencia']) . ";");
+                    $this->new_message("Reemplazo masivo en lineaspedidoscli reemplazada referencia " . $this->empresa->var2str($_POST['referencia']) . " por " . $this->empresa->var2str($_POST['nreferencia']), true);
+                }
+
+                if ($this->db->table_exists('lineaspedidosprov')) {
+                    $this->db->exec("UPDATE lineaspedidosprov SET referencia = " . $this->empresa->var2str($_POST['nreferencia'])
+                        . " WHERE referencia = " . $this->empresa->var2str($_POST['referencia']) . ";");
+                    $this->new_message("Reemplazo masivo en lineaspedidosprov reemplazada referencia " . $this->empresa->var2str($_POST['referencia']) . " por " . $this->empresa->var2str($_POST['nreferencia']), true);
+                }
+
+                /// esto es una personalización del plugin producción, será eliminado este código en futuras versiones.
+                if ($this->db->table_exists('lineasfabricados')) {
+                    $this->db->exec("UPDATE lineasfabricados SET referencia = " . $this->empresa->var2str($_POST['nreferencia'])
+                        . " WHERE referencia = " . $this->empresa->var2str($_POST['referencia']) . ";");
+                    $this->new_message("Reemplazo masivo en lineasfabricados reemplazada referencia " . $this->empresa->var2str($_POST['referencia']) . " por " . $this->empresa->var2str($_POST['nreferencia']), true);
+                }
             }
         } else {
             $this->new_error_msg("¡Error al guardar el articulo!");

--- a/view/ventas_articulo.html
+++ b/view/ventas_articulo.html
@@ -35,6 +35,38 @@
          });
          {/if}
       });
+      
+      $("#b_guardar_articulo").click(function(event) {
+          var referencia = $("#form_articulo input[name=referencia]").val();
+          var nreferencia = $("#form_articulo input[name=nreferencia]").val();
+          console.log(referencia);
+          console.log(nreferencia);
+          if (referencia != nreferencia) {
+              var msg = '¿Estas seguro de que quieres cambiar la referencia del articulo de <b>' + referencia + '</b> a <b>' + nreferencia + '</b>?<br/><br/>' +
+                      'Este cambio reajustará la referencia en todos los documentos en los que aparezca.';
+              bootbox.confirm({
+                message: msg,
+                title: '<b>Atención</b>',
+                callback: function(result) {
+                   if (result) {
+                        bootbox.alert({
+                            message: 'Cambio de referencia confirmado, se almacenará como cambio masivo realizado por tu usuario.',
+                            title: "<b>Atención</b>"
+                        });
+                        $("#b_guardar_articulo").disabled = true;
+                        $("#form_articulo").submit();
+                   } else {
+                       $("#form_articulo input[name=nreferencia]").val(referencia)
+                        $("#b_guardar_articulo").disabled = true;
+                        $("#form_articulo").submit();
+                   }
+                }
+             });
+          } else {
+              $("#b_guardar_articulo").disabled = true;
+              $("#form_articulo").submit();
+          }
+      });
    });
 </script>
 
@@ -158,7 +190,7 @@
    </ul>
    <div class="tab-content">
       <div role="tabpanel" class="tab-pane active" id="home">
-         <form action="{$fsc->url()}" method="post" class="post">
+         <form action="{$fsc->url()}" method="post" class="post" id="form_articulo">
             <input type="hidden" name="referencia" value="{$fsc->articulo->referencia}"/>
             <div class="container-fluid">
                <div class="row" style="padding-top: 10px;">
@@ -336,9 +368,9 @@
                      </div>
                   </div>
                   <div class="col-sm-2 text-right">
-                     <button class="btn btn-sm btn-primary" type="submit" onclick="this.disabled=true;this.form.submit();">
+                     <a href="#" id="b_guardar_articulo" class="btn btn-sm btn-primary">
                         <span class="glyphicon glyphicon-floppy-disk"></span>&nbsp; Guardar
-                     </button>
+                     </a>
                   </div>
                </div>
                <div class="row">
@@ -430,9 +462,9 @@
                   <span class="glyphicon glyphicon-trash"></span>&nbsp; Eliminar
                </a>
                {else}
-               <button class="btn btn-sm btn-primary" type="submit" onclick="this.disabled=true;this.form.submit();">
+               <a href="#" id="b_guardar_articulo" class="btn btn-sm btn-primary">
                   <span class="glyphicon glyphicon-floppy-disk"></span>&nbsp; Guardar
-               </button>
+               </a>
                {/if}
             </div>
          </div>

--- a/view/ventas_articulo.html
+++ b/view/ventas_articulo.html
@@ -36,12 +36,17 @@
          {/if}
       });
       
-      $("#b_guardar_articulo").click(function(event) {
-          var referencia = $("#form_articulo input[name=referencia]").val();
-          var nreferencia = $("#form_articulo input[name=nreferencia]").val();
-          console.log(referencia);
-          console.log(nreferencia);
+      $("#form_articulo").submit(function(event) {
+          $("#b_guardar_articulo").disabled = true;
+          
+          var referencia_sel = $("#form_articulo input[name=referencia]");
+          var referencia = referencia_sel.val();
+          var nreferencia_sel = $("#form_articulo input[name=nreferencia]");
+          var nreferencia = nreferencia_sel.val();
+
           if (referencia != nreferencia) {
+              event.preventDefault();
+              var $this = $(this);
               var msg = '¿Estas seguro de que quieres cambiar la referencia del articulo de <b>' + referencia + '</b> a <b>' + nreferencia + '</b>?<br/><br/>' +
                       'Este cambio reajustará la referencia en todos los documentos en los que aparezca.';
               bootbox.confirm({
@@ -53,18 +58,12 @@
                             message: 'Cambio de referencia confirmado, se almacenará como cambio masivo realizado por tu usuario.',
                             title: "<b>Atención</b>"
                         });
-                        $("#b_guardar_articulo").disabled = true;
-                        $("#form_articulo").submit();
                    } else {
-                       $("#form_articulo input[name=nreferencia]").val(referencia)
-                        $("#b_guardar_articulo").disabled = true;
-                        $("#form_articulo").submit();
+                       nreferencia_sel.val(referencia)
                    }
+                   $this.unbind('submit').submit();
                 }
              });
-          } else {
-              $("#b_guardar_articulo").disabled = true;
-              $("#form_articulo").submit();
           }
       });
    });

--- a/view/ventas_articulo.html
+++ b/view/ventas_articulo.html
@@ -367,9 +367,9 @@
                      </div>
                   </div>
                   <div class="col-sm-2 text-right">
-                     <a href="#" id="b_guardar_articulo" class="btn btn-sm btn-primary">
+                     <button id="b_guardar_articulo" class="btn btn-sm btn-primary" type="submit">
                         <span class="glyphicon glyphicon-floppy-disk"></span>&nbsp; Guardar
-                     </a>
+                     </button>
                   </div>
                </div>
                <div class="row">
@@ -461,9 +461,9 @@
                   <span class="glyphicon glyphicon-trash"></span>&nbsp; Eliminar
                </a>
                {else}
-               <a href="#" id="b_guardar_articulo" class="btn btn-sm btn-primary">
+               <button id="b_guardar_articulo" class="btn btn-sm btn-primary" type="submit">
                   <span class="glyphicon glyphicon-floppy-disk"></span>&nbsp; Guardar
-               </a>
+               </button>
                {/if}
             </div>
          </div>


### PR DESCRIPTION
Algunos usuarios no se daban cuenta de que estaban cambiando la referencia sin querer, por no pedirse confirmación, y por no indicarse que se harían cambios más allá del artículo en si mismo.

- Pide confirmación por JS para realizar un cambio de referencia
   - Si se acepta se aplica el cambio de referencia (entre otros cambios que puedan haber)
   - Si se rechaza, no se aplica el cambio de referencia (pero si otros cambios que puedan haber)
- Sólo ejecuta las SQL de UPDATE si la referencia es diferente a nreferencia
  - Al ejecutar las consultas muestra y almacena el mensaje, y se puede saber que agente lo ha realizado

**NOTA:** Antes de realizarse un cambio de referencia de esta forma, debería verificarse que la "nueva referencia" no está ocupada ya. Ya que en dicho caso, la DB queda con incoherencias, ya que el artículo no se ve alterado porque la referencia debe ser única, pero si lo hace en todas las líneas de los documentos. Por suerte se puede revertir con facilidad si alguien se da cuenta, ya que se puede detectar que hay una referencia diferente para la misma descripción comparandolo a nivel de línea de documento.